### PR TITLE
add lightstep MetricsSetup

### DIFF
--- a/kotlin/lib/src/main/kotlin/goodmetrics/downstream/GrpcTrailerLogger.kt
+++ b/kotlin/lib/src/main/kotlin/goodmetrics/downstream/GrpcTrailerLogger.kt
@@ -10,11 +10,13 @@ import io.grpc.MethodDescriptor
 import io.grpc.Status
 import io.grpc.Metadata as GrpcMetadata
 
-class GrpcTrailerLoggerInterceptor (
+class GrpcTrailerLoggerInterceptor(
     private val onTrailers: (Status, GrpcMetadata) -> Unit
 ) : ClientInterceptor {
     override fun <ReqT, RespT> interceptCall(
-        method: MethodDescriptor<ReqT, RespT>, callOptions: CallOptions, next: Channel
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel
     ): ClientCall<ReqT, RespT> {
         return TrailersLoggingClientCall(next.newCall(method, callOptions), onTrailers)
     }

--- a/kotlin/lib/src/test/kotlin/goodmetrics/IntegrationTest.kt
+++ b/kotlin/lib/src/test/kotlin/goodmetrics/IntegrationTest.kt
@@ -1,6 +1,6 @@
 package goodmetrics
 
-import goodmetrics.MetricsSetups.Companion.rowPerMetric
+import goodmetrics.MetricsSetups.Companion.goodMetrics
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -13,7 +13,7 @@ class IntegrationTest {
     @Test
     fun testMetrics() = runBlocking {
         val metricsBackgroundScope = CoroutineScope(Dispatchers.Default)
-        val (emitterJob, metricsFactory) = metricsBackgroundScope.rowPerMetric()
+        val (metricsFactory, _) = metricsBackgroundScope.goodMetrics()
 
         for (i in 1..1000) {
             metricsFactory.record("demo_app") { metrics ->
@@ -24,6 +24,5 @@ class IntegrationTest {
             }
         }
         metricsBackgroundScope.cancel()
-        emitterJob.join()
     }
 }

--- a/kotlin/lib/src/test/kotlin/goodmetrics/LightstepTester.kt
+++ b/kotlin/lib/src/test/kotlin/goodmetrics/LightstepTester.kt
@@ -1,94 +1,56 @@
 package goodmetrics
 
-import goodmetrics.downstream.GrpcTrailerLoggerInterceptor
+import goodmetrics.MetricsSetups.Companion.lightstepNativeOtlp
 import goodmetrics.downstream.OpentelemetryClient
 import goodmetrics.downstream.PrescientDimensions
-import goodmetrics.downstream.SecurityMode
-import goodmetrics.pipeline.Aggregator
-import goodmetrics.pipeline.SynchronizingBuffer
-import io.grpc.stub.MetadataUtils
-import kotlinx.coroutines.*
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.net.InetAddress
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
 fun main() {
-    val lightstepIngestHost = "ingest.lightstep.com"
-    val lightstepIngestPort = 443
-    val lightstepAuthHeader = "lightstep-access-token"
-    val lightstepToken = "redacted"
-
-    val authHeader = io.grpc.Metadata()
-    authHeader.put(io.grpc.Metadata.Key.of(lightstepAuthHeader, io.grpc.Metadata.ASCII_STRING_MARSHALLER), lightstepToken)
-
-    val trailersInterceptor = GrpcTrailerLoggerInterceptor { status, trailers ->
-        println("got trailers. Status: $status, Trailers: $trailers")
-    }
-
-    val client = OpentelemetryClient.connect(
-        sillyOtlpHostname = lightstepIngestHost,
-        port = lightstepIngestPort,
-        prescientDimensions = PrescientDimensions.AsResource(
-            mapOf(
-                "service.name" to Metrics.Dimension.String("service.name", "goodmetrics_test"),
-                "service.version" to Metrics.Dimension.String("service.version", OpentelemetryClient::class.java.`package`.implementationVersion ?: "dev"),
-                "host.hostname" to Metrics.Dimension.String("host.hostname", InetAddress.getLocalHost().hostName)
-            )
-        ),
-        securityMode = SecurityMode.Insecure,
-        interceptors = listOf(
-            MetadataUtils.newAttachHeadersInterceptor(authHeader),
-            trailersInterceptor
-        )
-    )
-
     runBlocking {
+        val configuredMetrics = lightstepNativeOtlp(
+            lightstepAccessToken = System.getenv("lightsteptoken") ?: "none",
+            prescientDimensions = PrescientDimensions.AsResource(
+                mapOf(
+                    "service.name" to Metrics.Dimension.String("service.name", "goodmetrics_test"),
+                    "service.version" to Metrics.Dimension.String("service.version", OpentelemetryClient::class.java.`package`.implementationVersion ?: "dev"),
+                    "host.hostname" to Metrics.Dimension.String("host.hostname", InetAddress.getLocalHost().hostName)
+                )
+            ),
+            aggregationWidth = 10.seconds,
+            logError = { message, exception -> println("metrics error: $message, ex: ${exception.message}") },
+            onSendUnary = { println("sending unary batch size: ${it.size}") },
+            onSendPreaggregated = { println("sending preaggregated batch size: ${it.size}") },
+        )
+
         launch {
-            runUnaryExample(client)
+            runUnaryExample(configuredMetrics.unaryMetricsFactory)
         }
         launch {
-            runPreaggregatedExample(client)
+            runPreaggregatedExample(configuredMetrics.preaggregatedMetricsFactory)
         }
     }
 }
 
-private suspend fun runPreaggregatedExample(client: OpentelemetryClient) = coroutineScope {
-    val sink = Aggregator(aggregationWidth = 1.seconds)
-    val preaggregatedFactory = MetricsFactory(
-        sink = sink,
-        timeSource = NanoTimeSource.fastNanoTime,
-        totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds,
-    )
-
-    launch {
-        // Launch the sender on a background coroutine.
-        sink.consume()
-            .collect { metrics ->
-                println("sending $metrics")
-                try {
-                    client.sendPreaggregatedBatch(
-                        listOf(metrics)
-                    )
-                } catch (e: Exception) {
-                    println("it broke while sending: $e")
-                    e.printStackTrace()
-                }
-            }
-    }
-
+private suspend fun runPreaggregatedExample(metricsFactory: MetricsFactory) = coroutineScope {
     var i = 0L
     var timestamp = TimeSource.Monotonic.markNow()
     val targetPeriod = 10.milliseconds
-    while(true) {
+    while (true) {
         // Run a high frequency service api. We'll call it high_frequency_api
         ++i
         try {
-            preaggregatedFactory.record("api_100hz") { metrics ->
+            metricsFactory.record("api_100hz") { metrics ->
                 metrics.dimension("a_dimension", i % 8)
                 metrics.distribution("random", ThreadLocalRandom.current().nextLong(4, 6))
+                metrics.distribution("free_memory", Runtime.getRuntime().freeMemory())
 
                 metrics.measure("small_random", ThreadLocalRandom.current().nextLong(4, 40))
             }
@@ -105,36 +67,14 @@ private suspend fun runPreaggregatedExample(client: OpentelemetryClient) = corou
         }
     }
 }
-private suspend fun runUnaryExample(client: OpentelemetryClient) = coroutineScope {
-    val sink = SynchronizingBuffer()
-    val unaryFactory = MetricsFactory(
-        sink = sink,
-        timeSource = NanoTimeSource.preciseNanoTime,
-        totaltimeType = MetricsFactory.TotaltimeType.MeasurementMicroseconds,
-    )
-
-    launch {
-        // Launch the sender on a background coroutine.
-        sink.consume()
-            .collect { metrics ->
-                println("sending $metrics")
-                try {
-                    client.sendMetricsBatch(
-                        listOf(metrics)
-                    )
-                } catch (e: Exception) {
-                    println("it broke while sending: $e")
-                    e.printStackTrace()
-                }
-            }
-    }
-
+private suspend fun runUnaryExample(metricsFactory: MetricsFactory) {
     repeat(Int.MAX_VALUE) { i ->
         // Run a service api. We'll call it "example"
         try {
-            unaryFactory.record("example") { metrics ->
+            metricsFactory.record("slower_example") { metrics ->
                 metrics.dimension("round", i.toLong() % 8)
                 metrics.measure("random", ThreadLocalRandom.current().nextFloat(0.3f, 0.97f))
+                metrics.measure("free_memory", Runtime.getRuntime().freeMemory())
                 delay(ThreadLocalRandom.current().nextLong(1, 13))
             }
         } catch (e: Exception) {


### PR DESCRIPTION
* Lots of configurability, might need more for stuff like retries.
* Adds a timeout to Lightstep requests.
* Fixes distributions for unary metrics.
  There still seems to be a bug with the way lightstep interprets
  the histogram with 1 bucket though. Unclear if there are more
  problems with it.
* switch the lightstep tester around to using the standard setup.
