### PR TITLE
work around lightstep histogram issue

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
@@ -140,7 +140,7 @@ fun Metrics.dimensionPosition(): DimensionPosition {
 }
 
 fun bucket(value: Long): Long {
-    if (value < 100L) return value
+    if (value < 100L) return max(0, value)
     val power = log(value.toDouble(), 10.0)
     val effectivePower = max(0, (power - 1).toInt())
     val trashColumn = 10.0.pow(effectivePower).toLong()
@@ -150,6 +150,16 @@ fun bucket(value: Long): Long {
     } else {
         value + trashColumn - trash
     }
+}
+
+fun bucketBelow(valueIn: Long): Long {
+    val value = valueIn - 1
+    if (value < 100L) return max(0, value)
+    val power = log(value.toDouble(), 10.0)
+    val effectivePower = max(0, (power - 0.00001 - 1).toInt())
+    val trashColumn = 10.0.pow(effectivePower).toLong()
+    val trash = value % trashColumn
+    return value - trash
 }
 
 sealed interface Aggregation {

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorKtTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorKtTest.kt
@@ -7,6 +7,9 @@ class AggregatorKtTest {
     private fun assertBucket(expected: Long, value: Long) {
         assertEquals(expected, bucket(value), "bucket( $value )")
     }
+    private fun assertBucketBelow(expected: Long, value: Long) {
+        assertEquals(expected, bucketBelow(value), "bucketBelow( $value )")
+    }
 
     @Test
     fun testBucket() {
@@ -21,8 +24,38 @@ class AggregatorKtTest {
         assertBucket(110, 101)
         assertBucket(110, 109)
         assertBucket(110, 110)
+        assertBucket(120, 120)
+        assertBucket(130, 121)
+        assertBucket(130, 123)
+        assertBucket(130, 129)
+        assertBucket(130, 130)
         assertBucket(120, 111)
         assertBucket(8900, 8891)
         assertBucket(8900, 8891)
+    }
+
+    @Test
+    fun testBucketBelow() {
+        assertBucketBelow(0, 0)
+        assertBucketBelow(0, 1)
+        assertBucketBelow(1, 2)
+        assertBucketBelow(8, 9)
+        assertBucketBelow(9, 10)
+        assertBucketBelow(10, 11)
+        assertBucketBelow(98, 99)
+        assertBucketBelow(99, 100)
+        assertBucketBelow(100, 101)
+        assertBucketBelow(100, 109)
+        assertBucketBelow(100, 110)
+        assertBucketBelow(110, 111)
+        assertBucketBelow(110, 120)
+        assertBucketBelow(120, 121)
+        assertBucketBelow(120, 123)
+        assertBucketBelow(120, 129)
+        assertBucketBelow(120, 130)
+        assertBucketBelow(130, 131)
+        assertBucketBelow(8800, 8891)
+        assertBucketBelow(8800, 8891)
+        assertBucketBelow(8900, 8901)
     }
 }


### PR DESCRIPTION
Lightstep can't handle a histogram with 1 populated bucket. It
interprets the bucket with data as covering a range from negative
infinity to the bucket value. This is a bug fix recommended by
Lightstep support to allow histograms with 1 value to show up,
but it remains unclear whether there are further issues in
lightstep interpreting sparse histograms.
