### PR TITLE
add manual Metrics lifetime path

### DIFF
--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsTest.kt
@@ -19,27 +19,27 @@ internal class MetricsTest {
     @Test
     fun testTimestampStart() {
         nowNanos = 13
-        val metrics = metricsFactory.getMetrics("test", TimestampAt.Start)
+        val metrics = metricsFactory.internals.getMetrics("test", TimestampAt.Start)
         metrics.assert(timestamp = 13)
     }
 
     @Test
     fun testTimestampEnd() {
         nowNanos = 13
-        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        val metrics = metricsFactory.internals.getMetrics("test", TimestampAt.End)
         metrics.assert(timestamp = -1)
 
         nowNanos = 17
-        metricsFactory.emit(metrics)
+        metricsFactory.internals.emit(metrics)
         metrics.assert(timestamp = 17)
     }
 
     @Test
     fun testEmitEmits() {
-        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        val metrics = metricsFactory.internals.getMetrics("test", TimestampAt.End)
         assertEquals(listOf(), emittedMetrics)
 
-        metricsFactory.emit(metrics)
+        metricsFactory.internals.emit(metrics)
         assertEquals(listOf(metrics), emittedMetrics)
     }
 
@@ -57,7 +57,7 @@ internal class MetricsTest {
 
     @Test
     fun testDimensionOverloads() {
-        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        val metrics = metricsFactory.internals.getMetrics("test", TimestampAt.End)
         metrics.dimension("1", true)
         metrics.dimension("2", false)
         metrics.dimension("3", 12L)
@@ -78,7 +78,7 @@ internal class MetricsTest {
 
     @Test
     fun testMeasureOverloads() {
-        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        val metrics = metricsFactory.internals.getMetrics("test", TimestampAt.End)
         metrics.measure("1", 1L)
         metrics.measure("2", 2L)
         metrics.measure("3", 3)
@@ -105,7 +105,7 @@ internal class MetricsTest {
 
     @Test
     fun testDistributionOverloads() {
-        val metrics = metricsFactory.getMetrics("test", TimestampAt.End)
+        val metrics = metricsFactory.internals.getMetrics("test", TimestampAt.End)
         metrics.distribution("1", 1L)
         metrics.distribution("2", 2L)
         metrics.distribution("3", 3)


### PR DESCRIPTION
Usually metrics should be consumed structurally in Kotlin - like
```
metricsFactory.record("interesting_work") { metrics ->
    // some stuff
}
```

but sometimes you have a workflow that revolves around a finite
state machine or the like. For that kind of workflow, the lifecycle
of a Metrics object may not map well to a stack frame. This change
gives an Internals view of the lifecycle methods the MetricsFactory
uses for those special use cases as an escape hatch.
