### PR TITLE
add base2 bucket dimensions

### DIFF
--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/Metrics.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/Metrics.kt
@@ -1,5 +1,7 @@
 package goodmetrics
 
+import goodmetrics.pipeline.bucketBase2
+
 /**
  * Not thread safe.
  */
@@ -48,6 +50,26 @@ data class Metrics internal constructor(
 
     fun dimension(dimension: String, value: String) {
         metricDimensions[dimension] = Dimension.String(dimension, value)
+    }
+
+    /**
+     * Record a dimension with a position based on log2(value).
+     * This method handles bucketing, just pass in a bytes count or whatever you need.
+     *
+     * This is a potentially expensive thing to use - you should carefully consider if
+     * you should use a distribution() instead. This will cause log2(maxvalue - minvalue)
+     * additional cardinality in your metrics. If you're using Goodmetrics and Timescale
+     * that's not a big deal - you'll buffer in memory for $reportInterval and ship it on.
+     * If you're using lightstep or something like that it's a factor to consider.
+     *
+     * You WANT to use this if you are trying to plot a latency BY request size.
+     * You DO NOT WANT to use this if you are trying to plot a latency or plot a
+     * request size.
+     *
+     * Positive values only.
+     */
+    fun dimensionBase2Bucketed(dimension: String, value: Long) {
+        metricDimensions[dimension] = Dimension.Number(dimension, bucketBase2(value))
     }
 
     fun measure(name: String, value: Long) {

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.DoubleAccumulator
 import java.util.concurrent.atomic.DoubleAdder
 import java.util.concurrent.atomic.LongAdder
+import kotlin.math.ceil
 import kotlin.math.log
 import kotlin.math.max
 import kotlin.math.pow
@@ -139,6 +140,9 @@ fun Metrics.dimensionPosition(): DimensionPosition {
         .toSet()
 }
 
+/**
+ * Base 10 2-significant-figures bucketing
+ */
 fun bucket(value: Long): Long {
     if (value < 100L) return max(0, value)
     val power = log(value.toDouble(), 10.0)
@@ -160,6 +164,14 @@ fun bucketBelow(valueIn: Long): Long {
     val trashColumn = 10.0.pow(effectivePower).toLong()
     val trash = value % trashColumn
     return value - trash
+}
+
+/**
+ * Base 2 bucketing. This is plain bucketing; no sub-steps, just the next highest base2 power of value.
+ */
+fun bucketBase2(value: Long): Long {
+    val power = ceil(log(value.toDouble(), 2.0))
+    return 2.0.pow(power).toLong()
 }
 
 sealed interface Aggregation {

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsTest.kt
@@ -64,6 +64,7 @@ internal class MetricsTest {
         metrics.dimension("4", 17L)
         metrics.dimension("5", "a")
         metrics.dimension("6", "b")
+        metrics.dimensionBase2Bucketed("7", 42)
         metrics.assert(
             dimensions = mapOf(
                 "1" to Metrics.Dimension.Boolean("1", true),
@@ -72,6 +73,7 @@ internal class MetricsTest {
                 "4" to Metrics.Dimension.Number("4", 17),
                 "5" to Metrics.Dimension.String("5", "a"),
                 "6" to Metrics.Dimension.String("6", "b"),
+                "7" to Metrics.Dimension.Number("7", 64),
             )
         )
     }

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorKtTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorKtTest.kt
@@ -11,6 +11,10 @@ class AggregatorKtTest {
         assertEquals(expected, bucketBelow(value), "bucketBelow( $value )")
     }
 
+    private fun assertBucketBase2(expected: Long, value: Long) {
+        assertEquals(expected, bucketBase2(value), "bucket( $value )")
+    }
+
     @Test
     fun testBucket() {
         assertBucket(0, 0)
@@ -57,5 +61,56 @@ class AggregatorKtTest {
         assertBucketBelow(8800, 8891)
         assertBucketBelow(8800, 8891)
         assertBucketBelow(8900, 8901)
+    }
+
+    @Test
+    fun testBucketBase2() {
+        assertBucketBase2(0, 0)
+        assertBucketBase2(1, 1)
+        assertBucketBase2(2, 2)
+        assertBucketBase2(4, 3)
+        assertBucketBase2(4, 4)
+        assertBucketBase2(8, 5)
+        assertBucketBase2(16, 9)
+        assertBucketBase2(16, 10)
+        assertBucketBase2(16, 11)
+        assertBucketBase2(128, 99)
+        assertBucketBase2(128, 100)
+        assertBucketBase2(128, 101)
+        assertBucketBase2(128, 109)
+        assertBucketBase2(128, 110)
+        assertBucketBase2(128, 120)
+        assertBucketBase2(128, 121)
+        assertBucketBase2(128, 123)
+        assertBucketBase2(128, 128)
+        assertBucketBase2(256, 129)
+        assertBucketBase2(256, 130)
+        assertBucketBase2(128, 111)
+        assertBucketBase2(16384, 8891)
+        assertBucketBase2(16384, 8901)
+
+        assertBucketBase2(0, -0)
+        assertBucketBase2(0, -1)
+        assertBucketBase2(0, -2)
+        assertBucketBase2(0, -3)
+        assertBucketBase2(0, -4)
+        assertBucketBase2(0, -5)
+        assertBucketBase2(0, -9)
+        assertBucketBase2(0, -10)
+        assertBucketBase2(0, -11)
+        assertBucketBase2(0, -99)
+        assertBucketBase2(0, -100)
+        assertBucketBase2(0, -101)
+        assertBucketBase2(0, -109)
+        assertBucketBase2(0, -110)
+        assertBucketBase2(0, -120)
+        assertBucketBase2(0, -121)
+        assertBucketBase2(0, -123)
+        assertBucketBase2(0, -128)
+        assertBucketBase2(0, -129)
+        assertBucketBase2(0, -130)
+        assertBucketBase2(0, -111)
+        assertBucketBase2(0, -8891)
+        assertBucketBase2(0, -8901)
     }
 }


### PR DESCRIPTION
a sharper tool, this lets users record byte sizes as dimensions more
conveniently. It's not an antipattern, but it's potentially hard on
some downstreams. It's fine for goodmetrics though, and lightstep
seems okay with it for now.
