### PR TITLE
fix aggregator distributions

### DIFF
--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
@@ -179,7 +179,7 @@ sealed interface Aggregation {
         val bucketCounts: ConcurrentHashMap<Long, LongAdder> = ConcurrentHashMap(),
     ) : Aggregation {
         fun accumulate(value: Long) {
-            bucketCounts.getOrPut(bucket(value), ::LongAdder).add(value)
+            bucketCounts.getOrPut(bucket(value), ::LongAdder).increment()
         }
     }
 


### PR DESCRIPTION
the feature was rushed and test coverage is sparse. This change
fixes the histogram to count occurrences at thresholds (as intended)
rather than the sum of the observations.
