### PR TITLE
Add MetricsBehavior flag and allow setting no totalime

### DIFF
--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/Metrics.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/Metrics.kt
@@ -2,6 +2,11 @@ package goodmetrics
 
 import goodmetrics.pipeline.bucketBase2
 
+enum class MetricsBehavior {
+    DEFAULT,
+    NO_TOTALTIME // don't include a `totaltime` timeseries for the metric
+}
+
 /**
  * Not thread safe.
  */
@@ -9,6 +14,7 @@ data class Metrics internal constructor(
     internal val name: String,
     internal var timestampNanos: Long,
     internal val startNanoTime: Long,
+    internal val metricsBehavior: MetricsBehavior = MetricsBehavior.DEFAULT,
 ) {
     sealed interface Dimension {
         val name: kotlin.String

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
@@ -62,6 +62,9 @@ class MetricsFactory(
      * the Metrics will be stamped with `totaltime` and emitted through the pipeline.
      */
     inline fun <T> record(name: String, stampAt: TimestampAt = TimestampAt.Start, block: (Metrics) -> T): T {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
         return recordWithBehavior(name, stampAt, MetricsBehavior.DEFAULT, block)
     }
 

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
@@ -60,10 +60,20 @@ class MetricsFactory(
     /**
      * Passes a Metrics into your scope. Record your unit of work; when the scope exits
      * the Metrics will be stamped with `totaltime` and emitted through the pipeline.
+     */
+    inline fun <T> record(name: String, stampAt: TimestampAt = TimestampAt.Start, block: (Metrics) -> T): T {
+        return recordWithBehavior(name, stampAt, MetricsBehavior.DEFAULT, block)
+    }
+
+    /**
+     * Passes a Metrics into your scope. Record your unit of work; when the scope exits
+     * the Metrics will be stamped with `totaltime` and emitted through the pipeline.
+     *
+     * Allows for setting specific MetricsBehaviors for the metric.
      *
      * If you don't want `totaltime` timeseries data, then specify `metricBehavior: MetricBehavior.NO_TOTALTIME`.
      */
-    inline fun <T> record(name: String, stampAt: TimestampAt = TimestampAt.Start, metricsBehavior: MetricsBehavior = MetricsBehavior.DEFAULT, block: (Metrics) -> T): T {
+    inline fun <T> recordWithBehavior(name: String, stampAt: TimestampAt = TimestampAt.Start, metricsBehavior: MetricsBehavior, block: (Metrics) -> T): T {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)
         }

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
@@ -104,10 +104,10 @@ class MetricsFactory(
         if (metrics.timestampNanos < 1) {
             metrics.timestampNanos = timeSource.epochNanos()
         }
-        val duration = System.nanoTime() - metrics.startNanoTime
         if (metrics.metricsBehavior == MetricsBehavior.NO_TOTALTIME) {
             return
         }
+        val duration = System.nanoTime() - metrics.startNanoTime
         when (totaltimeType) {
             TotaltimeType.DistributionMicroseconds -> metrics.distribution("totaltime", duration / 1000)
             TotaltimeType.MeasurementMicroseconds -> metrics.measure("totaltime", duration / 1000)

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
@@ -1,0 +1,133 @@
+package goodmetrics
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class MetricsFactoryTest {
+    private val emittedMetrics: MutableList<Metrics> = mutableListOf()
+    private var nowNanos = 0L
+
+    @BeforeTest
+    fun before() {
+        nowNanos = 0
+        emittedMetrics.clear()
+    }
+
+    @Test
+    fun testDistributionTotaltimeType() {
+        val metricsFactory = MetricsFactory(
+            sink = emittedMetrics::add,
+            timeSource = { nowNanos },
+            totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds
+        )
+
+        metricsFactory.record("test") { metrics ->
+            metrics.dimension("a_dimension", "a")
+            metrics.measure("a_measurement", 0)
+            metrics.distribution("a_distribution", 1)
+        }
+        assertEquals(1, emittedMetrics.size)
+        val metric = emittedMetrics[0]
+        metric.assertPresence(
+            dimensions = setOf("a_dimension"),
+            measurements = setOf("a_measurement"),
+            distributions = setOf("totaltime", "a_distribution")
+        )
+    }
+
+    @Test
+    fun testDistributionTotaltimeTypeNoTotaltimeBehavior() {
+        val metricsFactory = MetricsFactory(
+            sink = emittedMetrics::add,
+            timeSource = { nowNanos },
+            totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds
+        )
+
+        metricsFactory.record("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
+            metrics.dimension("a_dimension", "a")
+            metrics.measure("a_measurement", 0)
+            metrics.distribution("a_distribution", 1)
+        }
+        assertEquals(1, emittedMetrics.size)
+        val metric = emittedMetrics[0]
+        metric.assertPresence(
+            dimensions = setOf("a_dimension"),
+            measurements = setOf("a_measurement"),
+            distributions = setOf("a_distribution")
+        )
+    }
+
+    @Test
+    fun testMeasurementTotaltimeType() {
+        val metricsFactory = MetricsFactory(
+            sink = emittedMetrics::add,
+            timeSource = { nowNanos },
+            totaltimeType = MetricsFactory.TotaltimeType.MeasurementMicroseconds
+        )
+
+        metricsFactory.record("test") { metrics ->
+            metrics.dimension("a_dimension", "a")
+            metrics.measure("a_measurement", 0)
+            metrics.distribution("a_distribution", 1)
+        }
+        assertEquals(1, emittedMetrics.size)
+        val metric = emittedMetrics[0]
+        metric.assertPresence(
+            dimensions = setOf("a_dimension"),
+            measurements = setOf("totaltime", "a_measurement"),
+            distributions = setOf("a_distribution")
+        )
+    }
+
+    @Test
+    fun testMeasurementTotaltimeTypeNoTotaltimeBehavior() {
+        val metricsFactory = MetricsFactory(
+            sink = emittedMetrics::add,
+            timeSource = { nowNanos },
+            totaltimeType = MetricsFactory.TotaltimeType.MeasurementMicroseconds
+        )
+
+        metricsFactory.record("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
+            metrics.dimension("a_dimension", "a")
+            metrics.measure("a_measurement", 0)
+            metrics.distribution("a_distribution", 1)
+        }
+        assertEquals(1, emittedMetrics.size)
+        val metric = emittedMetrics[0]
+        metric.assertPresence(
+            dimensions = setOf("a_dimension"),
+            measurements = setOf("a_measurement"),
+            distributions = setOf("a_distribution")
+        )
+    }
+
+    @Test
+    fun testNoTotaltimeType() {
+        val metricsFactory = MetricsFactory(
+            sink = emittedMetrics::add,
+            timeSource = { nowNanos },
+            totaltimeType = MetricsFactory.TotaltimeType.None
+        )
+
+        metricsFactory.record("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
+            metrics.dimension("a_dimension", "a")
+            metrics.measure("a_measurement", 0)
+            metrics.distribution("a_distribution", 1)
+        }
+        assertEquals(1, emittedMetrics.size)
+        val metric = emittedMetrics[0]
+        metric.assertPresence(
+            dimensions = setOf("a_dimension"),
+            measurements = setOf("a_measurement"),
+            distributions = setOf("a_distribution")
+        )
+    }
+}
+
+fun Metrics.assertPresence(dimensions: Set<String>, measurements: Set<String>, distributions: Set<String>) {
+    val view = getView()
+    assertEquals(dimensions, view.dimensions.keys)
+    assertEquals(measurements, view.measurements.keys)
+    assertEquals(distributions, view.distributions.keys)
+}

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
@@ -44,7 +44,7 @@ internal class MetricsFactoryTest {
             totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds
         )
 
-        metricsFactory.record("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
+        metricsFactory.recordWithBehavior("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
             metrics.dimension("a_dimension", "a")
             metrics.measure("a_measurement", 0)
             metrics.distribution("a_distribution", 1)
@@ -88,7 +88,7 @@ internal class MetricsFactoryTest {
             totaltimeType = MetricsFactory.TotaltimeType.MeasurementMicroseconds
         )
 
-        metricsFactory.record("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
+        metricsFactory.recordWithBehavior("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
             metrics.dimension("a_dimension", "a")
             metrics.measure("a_measurement", 0)
             metrics.distribution("a_distribution", 1)

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
@@ -110,7 +110,7 @@ internal class MetricsFactoryTest {
             totaltimeType = MetricsFactory.TotaltimeType.None
         )
 
-        metricsFactory.record("test", metricsBehavior = MetricsBehavior.NO_TOTALTIME) { metrics ->
+        metricsFactory.record("test") { metrics ->
             metrics.dimension("a_dimension", "a")
             metrics.measure("a_measurement", 0)
             metrics.distribution("a_distribution", 1)


### PR DESCRIPTION
Currently the only way to make it so that no `totaltime` timeseries data for a metric is emitted is to set it at the `MetricsFactory` level with `TotaltimeType.NONE`.

However, many observability services (e.g. Lightstep, Datadog, Cloudwatch) charge per dimension and timeseries, so there may be cases where you want to more easily specify no `totaltime` for some metrics but not for others in order to reduce usage.

This adds a new `MetricsBehavior` enum that can be specified per metric.  For now, the only options for this are `DEFAULT` and `NO_TOTALTIME` (which, as the name suggests, means it won't include `totaltime`). In the future we may want to add an option e.g. to not include "prescient"/"environment" dimensions, among other possibilities.
