### PR TITLE
fix: impl autocloseable for metricsfactory and metricssink

### DIFF
--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsFactory.kt
@@ -35,7 +35,7 @@ class MetricsFactory(
     private val sink: MetricsSink,
     @PublishedApi internal val timeSource: NanoTimeSource,
     private val totaltimeType: TotaltimeType
-) {
+) : AutoCloseable {
     /**
      * Tools for making abstractions around the metrics factory other than the usual record{} pattern.
      */
@@ -126,5 +126,9 @@ class MetricsFactory(
             TotaltimeType.MeasurementMicroseconds -> metrics.measure("totaltime", duration / 1000)
             TotaltimeType.None -> {}
         }
+    }
+
+    override fun close() {
+        sink.close()
     }
 }

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsSetups.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/MetricsSetups.kt
@@ -161,14 +161,20 @@ class MetricsSetups private constructor() {
                 compressionMode = compressionMode,
             )
 
-            val unarySink = MetricsSink { metrics ->
-                runBlocking {
-                    onSendUnary(listOf(metrics))
-                    try {
-                        client.sendMetricsBatch(listOf(metrics))
-                    } catch (e: Exception) {
-                        logError("error while sending blocking metrics", e)
+            val unarySink = object : MetricsSink {
+                override fun emit(metrics: Metrics) {
+                    runBlocking {
+                        onSendUnary(listOf(metrics))
+                        try {
+                            client.sendMetricsBatch(listOf(metrics))
+                        } catch (e: Exception) {
+                            logError("error while sending blocking metrics", e)
+                        }
                     }
+                }
+
+                override fun close() {
+                    client.close()
                 }
             }
 

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/downstream/OpentelemetryClient.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/downstream/OpentelemetryClient.kt
@@ -74,7 +74,7 @@ class OpentelemetryClient(
     private val timeout: Duration,
     private val logRawPayload: (ResourceMetrics) -> Unit = { },
     private val compressionMode: CompressionMode,
-) {
+) : AutoCloseable {
     companion object {
         fun connect(
             sillyOtlpHostname: String = "localhost",
@@ -371,5 +371,9 @@ class OpentelemetryClient(
                 value = anyValue { stringValue = v.value }
             }
         }
+    }
+
+    override fun close() {
+        channel.shutdown()
     }
 }

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
@@ -125,6 +125,10 @@ class Aggregator(
             }
         }
     }
+
+    override fun close() {
+        // nothing to do here now
+    }
 }
 
 typealias DimensionPosition = Set<Metrics.Dimension>

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/MetricsSink.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/MetricsSink.kt
@@ -2,6 +2,6 @@ package goodmetrics.pipeline
 
 import goodmetrics.Metrics
 
-fun interface MetricsSink {
+interface MetricsSink : AutoCloseable {
     fun emit(metrics: Metrics)
 }

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/SynchronizingBuffer.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/SynchronizingBuffer.kt
@@ -26,6 +26,10 @@ class SynchronizingBuffer(
         metricsQueue.trySend(metrics)
     }
 
+    override fun close() {
+        metricsQueue.close()
+    }
+
     private fun failedToDeliver(_metrics: Metrics) {
         // TODO: record metrics
     }

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsFactoryTest.kt
@@ -1,11 +1,21 @@
 package goodmetrics
 
+import goodmetrics.pipeline.MetricsSink
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class MetricsFactoryTest {
     private val emittedMetrics: MutableList<Metrics> = mutableListOf()
+    private val testMetricsSink = object : MetricsSink {
+        override fun emit(metrics: Metrics) {
+            emittedMetrics.add(metrics)
+        }
+
+        override fun close() {
+            // nothing to do here
+        }
+    }
     private var nowNanos = 0L
 
     @BeforeTest
@@ -17,7 +27,7 @@ internal class MetricsFactoryTest {
     @Test
     fun testDistributionTotaltimeType() {
         val metricsFactory = MetricsFactory(
-            sink = emittedMetrics::add,
+            sink = testMetricsSink,
             timeSource = { nowNanos },
             totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds
         )
@@ -39,7 +49,7 @@ internal class MetricsFactoryTest {
     @Test
     fun testDistributionTotaltimeTypeNoTotaltimeBehavior() {
         val metricsFactory = MetricsFactory(
-            sink = emittedMetrics::add,
+            sink = testMetricsSink,
             timeSource = { nowNanos },
             totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds
         )
@@ -61,7 +71,7 @@ internal class MetricsFactoryTest {
     @Test
     fun testMeasurementTotaltimeType() {
         val metricsFactory = MetricsFactory(
-            sink = emittedMetrics::add,
+            sink = testMetricsSink,
             timeSource = { nowNanos },
             totaltimeType = MetricsFactory.TotaltimeType.MeasurementMicroseconds
         )
@@ -83,7 +93,7 @@ internal class MetricsFactoryTest {
     @Test
     fun testMeasurementTotaltimeTypeNoTotaltimeBehavior() {
         val metricsFactory = MetricsFactory(
-            sink = emittedMetrics::add,
+            sink = testMetricsSink,
             timeSource = { nowNanos },
             totaltimeType = MetricsFactory.TotaltimeType.MeasurementMicroseconds
         )
@@ -105,7 +115,7 @@ internal class MetricsFactoryTest {
     @Test
     fun testNoTotaltimeType() {
         val metricsFactory = MetricsFactory(
-            sink = emittedMetrics::add,
+            sink = testMetricsSink,
             timeSource = { nowNanos },
             totaltimeType = MetricsFactory.TotaltimeType.None
         )

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/MetricsTest.kt
@@ -1,5 +1,6 @@
 package goodmetrics
 
+import goodmetrics.pipeline.MetricsSink
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -7,13 +8,22 @@ import kotlin.test.assertEquals
 internal class MetricsTest {
     private lateinit var metricsFactory: MetricsFactory
     private val emittedMetrics: MutableList<Metrics> = mutableListOf()
+    private val testMetricsSink = object : MetricsSink {
+        override fun emit(metrics: Metrics) {
+            emittedMetrics.add(metrics)
+        }
+
+        override fun close() {
+            // nothing to do here
+        }
+    }
     private var nowNanos = 0L
 
     @BeforeTest
     fun before() {
         nowNanos = 0
         emittedMetrics.clear()
-        metricsFactory = MetricsFactory(sink = emittedMetrics::add, timeSource = { nowNanos }, totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds)
+        metricsFactory = MetricsFactory(sink = testMetricsSink, timeSource = { nowNanos }, totaltimeType = MetricsFactory.TotaltimeType.DistributionMicroseconds)
     }
 
     @Test


### PR DESCRIPTION
seeing a lot of errors like 

```
SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=417, target=ingest.lightstep.com:443} was not shutdown properly!!! ~*~*~*
```

Inside of reused lambda containers, this pr should fix these errors