### PR TITLE
feat: add support for Otlp exponential histograms

### DIFF
--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/downstream/GoodmetricsClient.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/downstream/GoodmetricsClient.kt
@@ -17,6 +17,7 @@ import io.goodmetrics.statisticSet
 import io.grpc.netty.GrpcSslContexts
 import io.grpc.netty.NettyChannelBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import kotlin.math.roundToLong
 
 class GoodmetricsClient private constructor(
     private val stub: MetricsGrpcKt.MetricsCoroutineStub,
@@ -153,6 +154,14 @@ fun Aggregation.toProto(): Measurement = measurement {
             histogram = histogram {
                 for ((bucket, count) in this@toProto.bucketCounts) {
                     buckets[bucket] = count.sum()
+                }
+            }
+        }
+        is Aggregation.ExponentialHistogram -> {
+            val bucketCounts = this@toProto.valueCounts().map { (value, count) -> Pair(value.roundToLong(), count)}.toMap()
+            histogram = histogram {
+                for ((bucket, count) in bucketCounts) {
+                    buckets[bucket] = count
                 }
             }
         }

--- a/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
+++ b/kotlin/goodmetrics/src/main/kotlin/goodmetrics/pipeline/Aggregator.kt
@@ -9,10 +9,16 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.DoubleAccumulator
 import java.util.concurrent.atomic.DoubleAdder
 import java.util.concurrent.atomic.LongAdder
+import kotlin.math.E
+import kotlin.math.absoluteValue
 import kotlin.math.ceil
+import kotlin.math.exp
+import kotlin.math.floor
 import kotlin.math.log
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.pow
+import kotlin.math.sign
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -38,6 +44,27 @@ data class AggregatedBatch(
     val positions: MetricPositions,
 )
 
+/**
+ * When measuring distribution metrics, how do you want your metrics to be expressed?
+ */
+sealed interface DistributionMode {
+    fun getAggregations(dimensionPositionMap: DimensionPositionMap, position: DimensionPosition, name: String): Aggregation
+    object Histogram : DistributionMode {
+        override fun getAggregations(dimensionPositionMap: DimensionPositionMap, position: DimensionPosition, name: String): Aggregation {
+           return dimensionPositionMap
+               .getOrPut(position, ::AggregationMap)
+               .getOrPut(name, Aggregation::Histogram)
+        }
+    }
+    data class ExponentialHistogram(val desiredScale: Int) : DistributionMode {
+        override fun getAggregations(dimensionPositionMap: DimensionPositionMap, position: DimensionPosition, name: String): Aggregation {
+            return dimensionPositionMap
+                .getOrPut(position, ::AggregationMap)
+                .getOrPut(name) { Aggregation.ExponentialHistogram(desiredScale.toUInt()) }
+        }
+    }
+}
+
 private fun epochTime(epochMillis: Long): TimeMark {
     return object : TimeMark {
         override fun elapsedNow(): Duration {
@@ -53,7 +80,8 @@ private fun timeColumnMillis(divisor: Duration): Long {
 
 class Aggregator(
     private val aggregationWidth: Duration = 10.seconds,
-    private val delay_fn: suspend (duration: Duration) -> Unit = ::delay
+    private val delay_fn: suspend (duration: Duration) -> Unit = ::delay,
+    val distributionMode: DistributionMode
 ) : MetricsPipeline<AggregatedBatch>, MetricsSink {
     @Volatile
     private var currentBatch = MetricsMap()
@@ -107,20 +135,22 @@ class Aggregator(
                 is Aggregation.Histogram -> {
                     // TODO: logging
                 }
+                is Aggregation.ExponentialHistogram -> {
+                    // TODO: logging
+                }
             }
         }
 
-        // Distributions are histograms
         for ((name, value) in metrics.metricDistributions) {
-            val aggregation = metricPositions
-                .getOrPut(position, ::AggregationMap)
-                .getOrPut(name, Aggregation::Histogram)
-            when (aggregation) {
+            when (val aggregation = this.distributionMode.getAggregations(metricPositions, position, name)) {
                 is Aggregation.StatisticSet -> {
                     // TODO: Logging
                 }
                 is Aggregation.Histogram -> {
                     aggregation.accumulate(value)
+                }
+                is Aggregation.ExponentialHistogram -> {
+                    aggregation.accumulate(value.toDouble())
                 }
             }
         }
@@ -178,7 +208,181 @@ fun bucketBase2(value: Long): Long {
     return 2.0.pow(power).toLong()
 }
 
+// log_2(e). This is the most precision the JVM will give us
+const val LOG2_E = 1.4426950408889634;
+
+// ln_2. This is the most precision the JVM will give us
+const val LN_2 = 0.6931471805599453;
+
 sealed interface Aggregation {
+    data class ExponentialHistogram(
+        /**
+         * Desired scale will drop as necessary to match the static max buckets configuration.
+         * This will happen dynamically in response to observed range. If your distribution
+         * range falls within 160 contiguous buckets somewhere the desired scale's range, then
+         * your output scale will match your desired scale. If your observed range exceeds 160
+         * buckets then scale will be reduced to reflect the data's width.
+         */
+        var actualScale: UInt,
+        val maxBucketCount: UInt = 160u,
+        var bucketStartOffset: UInt = 0u,
+        val positiveBuckets: ArrayDeque<Long> = ArrayDeque(),
+        val negativeBuckets: ArrayDeque<Long> = ArrayDeque()
+    ) : Aggregation {
+
+        fun accumulate(value: Double) {
+            accumulateCount(value, 1)
+        }
+
+        private fun accumulateCount(value: Double, count: Long) {
+            // This may be before or after the current range, and that range might need to be expanded.
+            val scaleIndex = mapValueToScaleIndex(actualScale.toInt(), value)
+
+            // Initialize the histogram to center on the first data point. That should probabilistically
+            // reduce the amount of shifting we do over time, for normal distributions.
+            if (isEmpty()) {
+                bucketStartOffset = scaleIndex - maxBucketCount / 2u
+            }
+
+            var localIndex = scaleIndex.toInt() - bucketStartOffset.toInt()
+
+            while (localIndex < 0 && rotateRangeDownOneIndex()) {
+                localIndex++
+            }
+
+            while (maxBucketCount.toInt() <= localIndex && rotateRangeUpOneIndex()) {
+                localIndex--
+            }
+
+            if (localIndex < 0 || maxBucketCount.toInt() <= localIndex) {
+                if (zoomOut()) {
+                    accumulateCount(value, count)
+                    return
+                }
+                // if we didn't zoom out then we're at the end of the range.
+                localIndex = maxBucketCount.toInt() - 1
+            }
+
+            val index = min(maxBucketCount - 1u, localIndex.toUInt())
+            val buckets = getMutableBucketsForValue(value)
+            val size = max(0, (index.toInt() - buckets.size)+ 1)
+            buckets.addAll(List(size) { 0 })
+            buckets[index.toInt()] += count
+        }
+
+        private fun zoomOut(): Boolean {
+            if (actualScale == 0u) {
+                return false
+            }
+            val oldScale = actualScale.toInt()
+            val oldBucketStartOffset = bucketStartOffset
+            val oldPositives = takePositives()
+            val oldNegatives = takeNegatives()
+
+            actualScale--
+            bucketStartOffset = 0u
+
+            // now just re-ingest
+            for ((oldIndex, count) in oldPositives.withIndex()) {
+                if (0 < count) {
+                    val value = lowerBoundary(oldScale, (oldBucketStartOffset + oldIndex.toUInt()))
+                    accumulateCount(value, count)
+                }
+            }
+            for ((oldIndex, count) in oldNegatives.withIndex()) {
+                if (0 < count) {
+                    val value = -lowerBoundary(oldScale, (oldBucketStartOffset + oldIndex.toUInt()))
+                    accumulateCount(value, count)
+                }
+            }
+
+            return true
+        }
+
+        private fun rotateRangeDownOneIndex(): Boolean {
+            if (positiveBuckets.size < maxBucketCount.toInt() && negativeBuckets.size < maxBucketCount.toInt()) {
+                if (!positiveBuckets.isEmpty()) {
+                    positiveBuckets.addFirst(0)
+                }
+                if (!negativeBuckets.isEmpty()) {
+                    negativeBuckets.addFirst(0)
+                }
+                bucketStartOffset--
+                return true
+            }
+            return false
+        }
+
+        private fun rotateRangeUpOneIndex(): Boolean {
+            if ((positiveBuckets.firstOrNull() ?: 0L) == 0L && (negativeBuckets.firstOrNull() ?: 0L) == 0L) {
+                positiveBuckets.removeFirstOrNull()
+                negativeBuckets.removeFirstOrNull()
+                bucketStartOffset++
+                return true
+            }
+            return false
+        }
+
+        private fun getMutableBucketsForValue(value: Double): ArrayDeque<Long> {
+            return if (value.sign == 1.0) {
+                positiveBuckets
+            } else {
+                negativeBuckets
+            }
+        }
+
+        private fun isEmpty(): Boolean = positiveBuckets.isEmpty() && negativeBuckets.isEmpty()
+
+        fun count(): Long = positiveBuckets.sum() + negativeBuckets.sum()
+
+        /**
+         * This is an approximation, just using the positive buckets for the sum.
+         */
+        fun sum(): Double = positiveBuckets.mapIndexed { index, count -> lowerBoundary(actualScale.toInt(), index.toUInt()) * count }.sum()
+
+        /**
+         * This is an approximation, just using the positive buckets for the min.
+         */
+        fun min(): Double {
+            return positiveBuckets.withIndex().firstOrNull { 0 < it.value }?.let { lowerBoundary(actualScale.toInt(), it.index.toUInt()) } ?: 0.0
+        }
+
+        fun max(): Double {
+            return positiveBuckets.withIndex().lastOrNull { 0 < it.value }?.let { lowerBoundary(actualScale.toInt(), it.index.toUInt()) } ?: 0.0
+        }
+
+        fun scale(): Int = actualScale.toInt()
+
+        fun bucketStartOffset(): Int = bucketStartOffset.toInt()
+
+        fun takePositives(): ArrayDeque<Long> {
+            val positives = ArrayDeque(positiveBuckets)
+            this.positiveBuckets.clear()
+            return positives
+        }
+
+        fun takeNegatives(): ArrayDeque<Long> {
+            val negatives = ArrayDeque(negativeBuckets)
+            this.negativeBuckets.clear()
+            return negatives
+        }
+
+        fun hasNegatives(): Boolean = this.negativeBuckets.isNotEmpty()
+
+        fun valueCounts(): Sequence<Pair<Double, Long>> {
+            return this.negativeBuckets.mapIndexed { index, count ->
+                Pair(
+                    lowerBoundary(actualScale.toInt(), bucketStartOffset + index.toUInt()),
+                    count
+                )
+            }.asSequence() + this.positiveBuckets.mapIndexed { index, count ->
+                Pair(
+                    lowerBoundary(actualScale.toInt(), bucketStartOffset + index.toUInt()),
+                    count
+                )
+            }.asSequence()
+        }
+    }
     data class Histogram(
         val bucketCounts: ConcurrentHashMap<Long, LongAdder> = ConcurrentHashMap(),
     ) : Aggregation {
@@ -201,4 +405,25 @@ sealed interface Aggregation {
             count.add(1)
         }
     }
+}
+
+/**
+ * treats negative numbers as positive - you gotta accumulate into a negative array
+ */
+fun mapValueToScaleIndex(scale: Int, rawValue: Number): UInt {
+    val value = rawValue.toDouble().absoluteValue
+    val scaleFactor = LOG2_E * 2.0.pow(scale)
+    return floor(log(value, E) * scaleFactor).toUInt()
+}
+
+/**
+ * obviously only supports positive indices. If you want a negative boundary, flip the sign on the return value.
+ * per the wonkadoo instructions found at: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram
+ *   > The positive and negative ranges of the histogram are expressed separately. Negative values are mapped by
+ *   > their absolute value into the negative range using the same scale as the positive range. Note that in the
+ *   > negative range, therefore, histogram buckets use lower-inclusive boundaries.
+ */
+fun lowerBoundary(scale: Number, index: UInt): Double {
+    val inverseScaleFactor = LN_2 * 2.0.pow(-scale.toInt())
+    return exp(index.toDouble() * inverseScaleFactor)
 }

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorTest.kt
@@ -327,7 +327,7 @@ internal class AggregatorTest {
         }
     }
 
-    // Verify multi threaded access is indeed safe
+    // Verify multithreaded access is indeed safe
     @Test
     fun testExponentialHistogramMultiThreadedAccess() {
         val e = Aggregation.ExponentialHistogram(0u)
@@ -343,9 +343,17 @@ internal class AggregatorTest {
         while (!executorService.isTerminated) {
             // wait
         }
+        assertEquals(1, e.positiveBuckets.size)
         // Should be 10_000 * 8
-        assertEquals(80000, e.count())
+        assertEquals(80_000, e.count())
         // Should be the result of 80_000 times `e.accumulate(1.0)` is called
-        assertEquals(9.671406556917032E28, e.sum())
+        assertEquals(80_000.0, e.sum())
+    }
+
+    @Test
+    fun testSaturatingSub() {
+        assertTrue(57u.saturatingSub(42u) > 0u)
+        assertEquals(0u, 57u.saturatingSub(160u))
+        assertEquals(4_294_967_294u, 4_294_967_295u.saturatingSub(1u))
     }
 }

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorTest.kt
@@ -341,9 +341,9 @@ internal class AggregatorTest {
                 delay(5.milliseconds)
                 e.accumulate(50_000_000.0)
                 // Wait while coroutine 2 does more aggregations
-                delay(2.milliseconds)
+                delay(5.milliseconds)
                 // Both should be asserting the same thing is true
-                assertTrue(e.count() >= 5)
+                assertEquals(5, e.count())
             },
             // coroutine 2
             launch {
@@ -361,7 +361,7 @@ internal class AggregatorTest {
                 e.accumulate(42_000_000.0)
                 delay(2.milliseconds)
                 // Both should be asserting the same thing is true
-                assertTrue(e.count() >= 5)
+                assertEquals(5, e.count())
             }
         ).joinAll()
 

--- a/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorTest.kt
+++ b/kotlin/goodmetrics/src/test/kotlin/goodmetrics/pipeline/AggregatorTest.kt
@@ -1,6 +1,8 @@
 package goodmetrics.pipeline
 
 import goodmetrics.Metrics
+import kotlin.math.absoluteValue
+import kotlin.random.Random
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -9,12 +11,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 internal class AggregatorTest {
     lateinit var gotBatch: Mutex
     lateinit var aggregatorSleep: Mutex
 
+    private val epsilon = 1.0 / 128.0
     val batches = mutableListOf<AggregatedBatch>()
 
     fun endAggregatorSleep() {
@@ -24,6 +28,17 @@ internal class AggregatorTest {
 
     suspend fun sleepAggregator() {
         aggregatorSleep.lock()
+    }
+
+    private fun assertEqualsEpsilon(j: Double, k: Double, message: String) {
+        val difference = (j - k).absoluteValue
+        assertTrue(difference < epsilon, "$message: $j != $k with epsilon $epsilon")
+    }
+
+    private fun assertValueLowerBoundary(exponentialHistogram: Aggregation.ExponentialHistogram, value: Number, expectedLowerBoundary: Number) {
+        val observedIndex = mapValueToScaleIndex(exponentialHistogram.scale(), value.toDouble())
+        val observedBoundary = lowerBoundary(exponentialHistogram.scale(), observedIndex)
+        assertEqualsEpsilon(expectedLowerBoundary.toDouble(), observedBoundary, "boundary matches")
     }
 
     @BeforeTest
@@ -48,9 +63,9 @@ internal class AggregatorTest {
         return m
     }
 
-    private fun testOneWindow(runWindow: (Aggregator) -> Unit): AggregatedBatch {
+    private fun testOneWindow(distributionMode: DistributionMode = DistributionMode.Histogram, runWindow: (Aggregator) -> Unit): AggregatedBatch {
         return runBlocking {
-            val aggregator = Aggregator(aggregationWidth = 1.seconds, delay_fn = ::oneSecondDelay)
+            val aggregator = Aggregator(aggregationWidth = 1.seconds, delay_fn = ::oneSecondDelay, distributionMode = distributionMode)
             val collectorJob = launch {
                 aggregator.consume().collect { batch ->
                     batches.add(batch)
@@ -111,5 +126,201 @@ internal class AggregatorTest {
 
     @Test
     fun emit() {
+    }
+
+
+
+    @Test
+    fun testMapValueToScaleIndex() {
+        assertEquals(1275u, mapValueToScaleIndex(6, 1_000_000))
+        assertEquals(1275u + 160u, mapValueToScaleIndex(6, 5_650_000))
+
+        assertEquals(637u, mapValueToScaleIndex(5, 1_000_000))
+        assertEquals(637u + 160u, mapValueToScaleIndex(5, 32_000_000))
+    }
+
+    @Test
+    fun testIndicesScaleZeroPositiveNumbers() {
+        val e = Aggregation.ExponentialHistogram(0u)
+        assertEquals(0u, mapValueToScaleIndex(e.scale(), 0))
+        assertValueLowerBoundary(e, 0, 1)
+        assertValueLowerBoundary(e, 1, 1)
+        assertValueLowerBoundary(e, 2, 2)
+        assertValueLowerBoundary(e, 3, 2)
+        assertValueLowerBoundary(e, 4, 4)
+        assertValueLowerBoundary(e, 7, 4)
+        assertValueLowerBoundary(e, 8, 4)
+        assertValueLowerBoundary(e, 8.1, 8)
+    }
+
+    @Test
+    fun testIndicesScaleZeroNegativeNumbers() {
+        val e = Aggregation.ExponentialHistogram(0u)
+        assertEquals(0u, mapValueToScaleIndex(e.scale(), 0))
+        assertValueLowerBoundary(e, -0, 1)
+        assertValueLowerBoundary(e, -1, 1)
+        assertValueLowerBoundary(e, -2, 2)
+        assertValueLowerBoundary(e, -3, 2)
+        assertValueLowerBoundary(e, -4, 4)
+        assertValueLowerBoundary(e, -7, 4)
+        assertValueLowerBoundary(e, -8, 4)
+        assertValueLowerBoundary(e, -8.1, 8)
+    }
+
+    @Test
+    fun testIndicesScaleOnePositiveNumbers() {
+        val e = Aggregation.ExponentialHistogram(1u)
+        assertEquals(0u, mapValueToScaleIndex(e.scale(), 0))
+        assertValueLowerBoundary(e, 0, 1)
+        assertValueLowerBoundary(e, 1, 1)
+        assertValueLowerBoundary(e, 2, 2)
+        assertValueLowerBoundary(e, 3, 2.828)
+        assertValueLowerBoundary(e, 4, 4)
+        assertValueLowerBoundary(e, 7, 5.657)
+        assertValueLowerBoundary(e, 8, 5.657)
+        assertValueLowerBoundary(e, 8.1, 8)
+    }
+
+    @Test
+    fun testIndicesScaleTwoPositiveNumbers() {
+        val e = Aggregation.ExponentialHistogram(2u)
+        assertEquals(0u, mapValueToScaleIndex(e.scale(), 0))
+        assertValueLowerBoundary(e, 0, 1)
+        assertValueLowerBoundary(e, 1, 1)
+        assertValueLowerBoundary(e, 2, 2)
+        assertValueLowerBoundary(e, 3, 2.828)
+        assertValueLowerBoundary(e, 4, 4)
+        assertValueLowerBoundary(e, 7, 6.727)
+        assertValueLowerBoundary(e, 8, 6.727)
+        assertValueLowerBoundary(e, 8.1, 8)
+    }
+
+    @Test
+    fun testIndicesScaleThreePositiveNumbers() {
+        val e = Aggregation.ExponentialHistogram(3u)
+        assertEquals(0u, mapValueToScaleIndex(e.scale(), 0))
+        assertValueLowerBoundary(e, 0, 1)
+        assertValueLowerBoundary(e, 1, 1)
+        assertValueLowerBoundary(e, 2, 2)
+        assertValueLowerBoundary(e, 3, 2.828)
+        assertValueLowerBoundary(e, 4, 4)
+        assertValueLowerBoundary(e, 7, 6.727)
+        assertValueLowerBoundary(e, 8, 7.337)
+        assertValueLowerBoundary(e, 8.1, 8)
+    }
+
+    @Test
+    fun testIndicesScaleFourPositiveNumbers() {
+        val e = Aggregation.ExponentialHistogram(4u)
+        assertEquals(0u, mapValueToScaleIndex(e.scale(), 0.0))
+        assertValueLowerBoundary(e, 0, 1)
+        assertValueLowerBoundary(e, 1, 1)
+        assertValueLowerBoundary(e, 2, 2)
+        assertValueLowerBoundary(e, 3, 2.954)
+        assertValueLowerBoundary(e, 4, 4)
+        assertValueLowerBoundary(e, 5, 4.967)
+        assertValueLowerBoundary(e, 6, 5.907)
+        assertValueLowerBoundary(e, 7, 6.727)
+        assertValueLowerBoundary(e, 8, 7.661)
+        assertValueLowerBoundary(e, 8.1, 8)
+    }
+
+    @Test
+    fun testIndicesScaleDowngradePositiveNumbers() {
+        val e = Aggregation.ExponentialHistogram(8u)
+        e.accumulate(24_000_000.0)
+        assertEquals(8, e.scale(), "initial value should not change scale since it falls in the numeric range")
+        assertEquals(81, e.positiveBuckets.size, "initial value should be in the middle")
+        assertEquals(1, e.positiveBuckets[80], "initial value should go in index 80 because that is halfway to 160")
+        assertEquals(6196, e.bucketStartOffset(), "bucket start offset should index into scale 8")
+
+        // assert some bucket boundaries for convenience
+        assertValueLowerBoundary(e, 24_000_000, 23984931.775)
+        assertValueLowerBoundary(e, 24_040_000, 23984931.775)
+        assertValueLowerBoundary(e, 24_050_000, 24049961.522)
+
+        assertEqualsEpsilon(19313750.368, lowerBoundary(8, 6196u), "lower boundary of histogram")
+        assertEqualsEpsilon(29785874.896, lowerBoundary(8, 6196u + 160u), "upper boundary of histogram")
+
+        // Accumulate some data in a bucket's range
+        for (i in 0 until 40_000) {
+            e.accumulate((24_000_000 + i).toDouble())
+        }
+
+        assertEquals(40_001, e.positiveBuckets[80], "initial value should go in index 80 because that is halfway to 160")
+
+        e.accumulate(24_050_000.0)
+        assertEquals(8, e.scale(), "a value in the next higher bucket should not change the scale")
+        assertEquals(82, e.positiveBuckets.size, "bucket count should be able to increase densely when a new bucket value is observed")
+        assertEquals(1, e.positiveBuckets[81], "index 81 has a new count")
+        assertEquals(6196, e.bucketStartOffset(), "bucket start offset does not change when adding a bucket in the same range")
+
+        // Poke at growth boundary conditions
+        e.accumulate(23_984_000.0)
+        assertEquals(8, e.scale(), "a value in the next lower bucket should not change the scale")
+        assertEquals(82, e.positiveBuckets.size, "bucket count should not increase when a new bucket value is observed within the covered range")
+        assertEquals(1, e.positiveBuckets[79], "index 79 has a new count")
+        assertEquals(6196, e.bucketStartOffset(), "bucket start offset does not change when using a bucket in the same range")
+
+        e.accumulate(19_313_750.0)
+        assertEquals(8, e.scale(), "a value below the covered range should not change the scale yet because there is room above the observed range to shift")
+        assertEquals(83, e.positiveBuckets.size, "bucket count should not increase when a new bucket value is observed within the covered range")
+        assertEquals(1, e.positiveBuckets[0], "index 0 has a new count")
+        assertEquals(6195, e.bucketStartOffset(), "bucket start offset changes because we rotated down 1 position")
+        assertEqualsEpsilon(29705335.561, lowerBoundary(8, 6195u + 160u), "new upper boundary of histogram")
+
+        //
+        // -------- Expand histogram range with a big number --------
+        //
+        e.accumulate(29_705_336.0)
+        assertEquals(3177u, mapValueToScaleIndex(7, 29_705_336.0), "this value pushes the length of scale 7 also")
+        assertEquals(7, e.scale(), "a value above the covered range should now change the scale because the lower end is populated while the upper end is beyond the range this scale can cover in 160 buckets")
+        assertEquals(160, e.positiveBuckets.size, "bucket count should be sensible after rescale")
+        assertEquals(1, e.positiveBuckets[e.positiveBuckets.size - 1], "last index has a new count")
+        assertEquals(3018, e.bucketStartOffset(), "bucket start offset changes because we scaled and rotated")
+
+        //
+        // -------- Skip several zoom scale steps in a single accumulate --------
+        //
+
+        val recursiveScaleStartCount = e.count()
+        assertEquals(2199023255551.996, lowerBoundary(2, 164u), "this value gets us down into scale 2")
+        assertEqualsEpsilon(4.0, lowerBoundary(2, 8u), "this value gets us down into scale 2")
+        assertEqualsEpsilon(4.757, lowerBoundary(2, 9u), "this value gets us down into scale 2")
+        // pin the bucket's low value, at scale 2's index 8. It's not in scale 2 yet though!
+        e.accumulate(4.25)
+        // now blow the range wide, way past scale 7, resulting in a recursive scale down from 7 to precision 2.
+        e.accumulate(2_199_023_255_552.0)
+        assertEquals(2, e.scale(), "this value range should force scale range 2")
+        assertEquals(8, e.bucketStartOffset(), "bucket start offset should match the first element, since we rotated and grew out to the larger value")
+        assertEquals(1, e.positiveBuckets[8 - 8], "this is the 4.0 bucket, and 4.25 should go in it.")
+        assertEquals(1, e.positiveBuckets[164 - 8], "this is the bucket for the big numer.")
+        assertEquals(recursiveScaleStartCount + 2, e.count(), "2 more reports were made. The histogram maintains every count across rescaling, even recursive rescaling")
+    }
+
+    // Helps us look for random index crashes
+    @Test
+    fun testExponentialHistogramFuzz() {
+        val start = System.nanoTime()
+        while ((System.nanoTime() - start).milliseconds < 50.milliseconds) {
+            val e = Aggregation.ExponentialHistogram(8u)
+            val innerStart = System.nanoTime()
+            while ((System.nanoTime() - innerStart).milliseconds < 1.milliseconds) {
+                e.accumulate(1_000_000_000_000_000.0 * Random.nextDouble())
+            }
+        }
+    }
+
+    // Helps us look for random index crashes
+    @Test
+    fun testExponentialHistogramFuzzNegative() {
+        val start = System.nanoTime()
+        while ((System.nanoTime() - start).milliseconds < 50.milliseconds) {
+            val e = Aggregation.ExponentialHistogram(8u)
+            val innerStart = System.nanoTime()
+            while ((System.nanoTime() - innerStart).milliseconds < 1.milliseconds) {
+                e.accumulate(-1_000_000_000_000_000.0 * Random.nextDouble())
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds support for Otlp exponential histograms. This is more or less the JVM implementation
of the [goodmetrics_rs](https://github.com/kvc0/goodmetrics_rs) feature.

Unit tests were grabbed from the latest `main` of [the Rust implementation's unit tests](https://github.com/kvc0/goodmetrics_rs/blob/main/lib/src/pipeline/aggregation/exponential_histogram.rs#L285),
so this helped ensure development was correct. That being said, it is entirely
possible I have missed something in the actual conversion to Otlp protocol.

I also added a new `sealed interface` called `DistributionMode` so consumers can explicitly set which aggregation mode they would
like to use. Considering exponential histograms are a "newer" technology, the default is set to `Histogram` so this new version
is not a breaking change.

Unit tests all pass and indicate that this behavior is correct.

The key difference here is that I opted _not_ to use a `LongAdder` for the buckets out of simplicity.
If that needs to change, I am more than happy to change that.
